### PR TITLE
Fix devcontainer.json for devaipod compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
     "name": "art_tools_dev_container",
-    "dockerComposeFile": [
-        "docker-compose.yaml"
-    ],
-    "service": "art-tools",
+    "build": {
+        "context": "..",
+        "dockerfile": ".devcontainer/Containerfile"
+    },
     "workspaceFolder": "/workspaces/art-tools",
     "containerEnv": {
         "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "art_tools_dev_container",
-    "image": "registry.fedoraproject.org/fedora:43",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "workspaceFolder": "/workspaces/art-tools",
     "containerEnv": {
         "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "art_tools_dev_container",
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "image": "ghcr.io/bootc-dev/devenv-debian:latest",
     "workspaceFolder": "/workspaces/art-tools",
     "containerEnv": {
         "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
     "name": "art_tools_dev_container",
-    "build": {
-        "context": "..",
-        "dockerfile": ".devcontainer/Containerfile"
-    },
+    "image": "registry.fedoraproject.org/fedora:43",
     "workspaceFolder": "/workspaces/art-tools",
     "containerEnv": {
         "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",


### PR DESCRIPTION
Replace dockerComposeFile with build directive to support devaipod. Devaipod requires either 'image' or 'build' field and doesn't support compose-based devcontainers.