### PR TITLE
ART-17451: stage-release FBC related images before build

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -129,6 +129,18 @@ PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
     "ocp": ("ocp-art-images-base-silent-ec", "art-images-base"),
 }
 
+# Per-version ReleasePlan name templates for FBC related-image advisory-stage release workflow.
+# Template uses {major} and {minor} placeholders; resolve via resolve_konflux_fbc_stage_release_plan().
+# Must stay aligned with konflux-release-data ReleasePlan resources per product tenant. See ART-17452.
+PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP = {
+    "ocp": "ocp-art-advisory-stage-{major}-{minor}",
+    "logging": "logging-advisory-stage-{major}-{minor}",
+    "openshift-logging": "logging-advisory-stage-{major}-{minor}",
+    "oadp": "oadp-advisory-stage-{major}-{minor}",
+    "rhmtc": "mtc-advisory-stage-{major}-{minor}",
+    "mta": "mta-advisory-stage-{major}-{minor}",
+}
+
 PRODUCT_KUBECONFIG_MAP = {
     "multicluster-engine": "ACM_KONFLUX_SA_KUBECONFIG",
     "rhacm2": "ACM_KONFLUX_SA_KUBECONFIG",

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -23,6 +23,7 @@ from artcommonlib.constants import (
     OCP5_BRIDGE_MINOR_BASE,
     PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP,
     PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP,
+    PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP,
     PRODUCT_KUBECONFIG_MAP,
     PRODUCT_NAMESPACE_MAP,
     RELEASE_SCHEDULES,
@@ -1366,6 +1367,33 @@ def resolve_konflux_base_image_release_targets(
         f"Using OCP defaults: releasePlan={default_plan!r}, application={default_app!r}"
     )
     return default_plan, default_app
+
+
+def resolve_konflux_fbc_stage_release_plan(product: str, major: int, minor: int) -> str:
+    """
+    Resolve the Konflux ReleasePlan name for FBC related-image advisory-stage release.
+
+    ReleasePlan names are per-version (e.g. ``ocp-art-advisory-stage-4-18``).
+    Must stay aligned with konflux-release-data ReleasePlan resources (see ART-17452).
+
+    Args:
+        product: Runtime product key (e.g. ocp, rhmtc, mta).
+        major: OCP major version.
+        minor: OCP minor version.
+
+    Returns:
+        ReleasePlan resource metadata.name.
+
+    Raises:
+        ValueError: If the product has no configured FBC stage release plan.
+    """
+    template = PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP.get(product)
+    if not template:
+        raise ValueError(
+            f"No FBC stage release plan configured for product '{product}'. "
+            f"Known products: {list(PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP.keys())}"
+        )
+    return template.format(major=major, minor=minor)
 
 
 async def run_safe(func: Callable[[], Any], failures_list: Optional[List[Tuple[str, Exception]]] = None) -> Any:

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -31,12 +31,20 @@ from async_lru import alru_cache
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, opm, util
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
+from doozerlib.backend.konflux_client import (
+    API_VERSION,
+    KIND_RELEASE,
+    KIND_RELEASE_PLAN,
+    KIND_SNAPSHOT,
+    ImageBuildParams,
+    KonfluxClient,
+)
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from doozerlib.image import ImageMetadata
 from doozerlib.record_logger import RecordLogger
 from elliottlib.shipment_utils import get_shipment_config_from_mr
+from kubernetes.dynamic import exceptions as k8s_exceptions
 from semver import VersionInfo
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
@@ -47,6 +55,21 @@ class AssemblyBundleCsvInfo(NamedTuple):
     csv_name: str
     skip_range: Optional[str]
     bundle_blob: Optional[Dict]  # The olm.bundle blob to add to the catalog
+
+
+class FbcRebaseResult(NamedTuple):
+    """Result of an FBC rebase — NVR and related image builds for stage release."""
+
+    nvr: str
+    ref_builds: List  # list[KonfluxBuildRecord] — operator + operands, excluding bundle
+
+
+class FbcRelatedImagesStageReleaseResult(NamedTuple):
+    """Result of stage-releasing FBC related images to a Konflux advisory-stage ReleasePlan."""
+
+    snapshot_name: str
+    release_name: str
+    release_url: str
 
 
 LOGGER = logging.getLogger(__name__)
@@ -1054,7 +1077,7 @@ class KonfluxFbcRebaser:
 
     async def rebase(
         self, metadata: ImageMetadata, bundle_build: KonfluxBundleBuildRecord, version: str, release: str
-    ) -> str:
+    ) -> FbcRebaseResult:
         bundle_short_name = metadata.get_olm_bundle_short_name()
         logger = self._logger.getChild(f"[{bundle_short_name}]")
         repo_dir = self.base_dir.joinpath(metadata.distgit_key)
@@ -1097,8 +1120,8 @@ class KonfluxFbcRebaser:
             )
 
             # Update the FBC repo
-            rebase_nvr = await self._rebase_dir(metadata, build_repo, bundle_build, version, release, logger)
-            assert rebase_nvr == nvr, f"rebase_nvr != nvr; doozer bug? {rebase_nvr} != {nvr}"
+            rebase_result = await self._rebase_dir(metadata, build_repo, bundle_build, version, release, logger)
+            assert rebase_result.nvr == nvr, f"rebase_nvr != nvr; doozer bug? {rebase_result.nvr} != {nvr}"
 
             # Validate the updated catalog
             logger.info("Validating the updated catalog")
@@ -1123,7 +1146,7 @@ class KonfluxFbcRebaser:
         finally:
             if self._record_logger:
                 self._record_logger.add_record("rebase_fbc_konflux", **record)
-        return nvr
+        return rebase_result
 
     async def _get_referenced_images(self, konflux_db: KonfluxDb, bundle_build: KonfluxBundleBuildRecord):
         assert bundle_build.operator_nvr, "operator_nvr is empty; doozer bug?"
@@ -1144,7 +1167,7 @@ class KonfluxFbcRebaser:
         version: str,
         release: str,
         logger: logging.Logger,
-    ) -> str:
+    ) -> FbcRebaseResult:
         logger.info("Rebasing dir %s", build_repo.local_dir)
 
         group_config = metadata.runtime.group_config
@@ -1191,7 +1214,9 @@ class KonfluxFbcRebaser:
         konflux_db: KonfluxDb = metadata.runtime.konflux_db
         konflux_db.bind(KonfluxBuildRecord)
         ref_builds = await self._get_referenced_images(konflux_db, bundle_build)
-        ref_builds.append(bundle_build)  # Include the bundle build itself
+        # Capture operator+operand builds BEFORE appending the bundle, for use in stage release.
+        stage_ref_builds = list(ref_builds)
+        ref_builds.append(bundle_build)  # Include the bundle build itself (for IDMS only)
         ref_pullspecs = {
             b.image_pullspec.replace(constants.REGISTRY_PROXY_BASE_URL, constants.BREW_REGISTRY_BASE_URL)
             for b in ref_builds
@@ -1452,7 +1477,7 @@ class KonfluxFbcRebaser:
         dfp.labels['com.redhat.art.name'] = name
         nvr = f'{name}-{version}-{release}'
         dfp.labels['com.redhat.art.nvr'] = nvr
-        return nvr
+        return FbcRebaseResult(nvr=nvr, ref_builds=stage_ref_builds)
 
     @staticmethod
     def _bootstrap_catalog(
@@ -1777,6 +1802,169 @@ class KonfluxFbcBuilder:
 
         except Exception:
             logger.exception("Error while syncing FBC related images to art-images-share")
+
+    async def stage_release_related_images(
+        self,
+        ref_builds: List[KonfluxBuildRecord],
+        release_plan_name: str,
+        operator_name: str,
+    ) -> FbcRelatedImagesStageReleaseResult:
+        """Stage-release operator + operand images via Konflux Snapshot → Release → wait.
+
+        Creates one multi-component Snapshot containing all related images, then creates a Release
+        referencing the advisory-stage ReleasePlan. If stage release fails, raises so the FBC build
+        is skipped.
+
+        Args:
+            ref_builds: Operator + operand build records from rebase (excluding bundle).
+            release_plan_name: Konflux ReleasePlan resource name for advisory-stage release.
+            operator_name: Operator distgit key, used for resource naming and logging.
+
+        Returns:
+            FbcRelatedImagesStageReleaseResult with snapshot name, release name, and release URL.
+
+        Raises:
+            ValueError: If ref_builds is empty.
+            RuntimeError: If ReleasePlan not found or release does not complete successfully.
+        """
+        if not ref_builds:
+            raise ValueError(f"No related image builds provided for operator '{operator_name}'. Cannot stage release.")
+
+        logger = self._logger.getChild(f"[stage-release:{operator_name}]")
+        application_name = util.konflux_application_name(self.group)
+
+        group_safe = artlib_util.normalize_group_name_for_k8s(self.group)
+        timestamp = artlib_util.get_utc_now_formatted_str()
+        # Max length budget: 63 - len("fbc-ri-stage-") - len(group_safe) - 2 dashes - len(timestamp)
+        max_operator_len = max(1, 63 - 13 - len(group_safe) - 2 - len(timestamp))
+        operator_safe = artlib_util.normalize_k8s_dns_label(operator_name, max_length=max_operator_len)
+        snapshot_name = f"fbc-ri-stage-{group_safe}-{operator_safe}-{timestamp}"
+        artlib_util.validate_k8s_dns_label(snapshot_name, "Generated FBC stage release snapshot name")
+
+        components = [
+            {
+                "name": artlib_util.normalize_k8s_dns_label(b.name, max_length=63),
+                "containerImage": b.image_pullspec,
+            }
+            for b in ref_builds
+        ]
+
+        logger.info(
+            "Stage-releasing %d related image(s) via ReleasePlan '%s' (application '%s')",
+            len(components),
+            release_plan_name,
+            application_name,
+        )
+
+        if self.dry_run:
+            logger.info(
+                "[DRY-RUN] Would create Snapshot '%s' with %d component(s) and Release via '%s'",
+                snapshot_name,
+                len(components),
+                release_plan_name,
+            )
+            return FbcRelatedImagesStageReleaseResult(
+                snapshot_name=snapshot_name,
+                release_name=f"dry-run-release-{snapshot_name}",
+                release_url="https://dry-run.invalid",
+            )
+
+        # Create Snapshot
+        snapshot_obj = {
+            "apiVersion": API_VERSION,
+            "kind": KIND_SNAPSHOT,
+            "metadata": {
+                "name": snapshot_name,
+                "namespace": self.konflux_namespace,
+                "labels": {
+                    "test.appstudio.openshift.io/type": "override",
+                    "appstudio.openshift.io/application": application_name,
+                },
+            },
+            "spec": {
+                "application": application_name,
+                "components": components,
+            },
+        }
+        result_snapshot = await self._konflux_client._create(snapshot_obj)
+        snapshot_url = self._konflux_client.resource_url(result_snapshot)
+        logger.info("Created Snapshot %s (%s)", snapshot_name, snapshot_url)
+
+        # Wait for Snapshot to be readable
+        timeout_s, poll_s, elapsed = 60, 10, 0
+        while elapsed < timeout_s:
+            try:
+                await self._konflux_client._get(API_VERSION, KIND_SNAPSHOT, snapshot_name)
+                break
+            except k8s_exceptions.NotFoundError:
+                await asyncio.sleep(poll_s)
+                elapsed += poll_s
+        else:
+            raise RuntimeError(f"Snapshot {snapshot_name} not available after 1 minute")
+
+        # Verify ReleasePlan exists before creating Release
+        try:
+            await self._konflux_client._get(API_VERSION, KIND_RELEASE_PLAN, release_plan_name)
+        except k8s_exceptions.NotFoundError:
+            raise RuntimeError(
+                f"ReleasePlan '{release_plan_name}' not found in namespace '{self.konflux_namespace}'. "
+                "Ensure ART-17452 has landed and the ReleasePlan name is correct."
+            ) from None
+
+        # Create Release
+        release_annotations = {
+            "art.redhat.com/kind": "fbc-ri-stage-release",
+            "art.redhat.com/group": self.group,
+            "art.redhat.com/assembly": self.assembly,
+            "art.redhat.com/operator": operator_name,
+        }
+        if job_url := os.getenv("BUILD_URL"):
+            release_annotations["art.redhat.com/job-url"] = job_url
+
+        release_obj = {
+            "apiVersion": API_VERSION,
+            "kind": KIND_RELEASE,
+            "metadata": {
+                "generateName": f"fbc-ri-stage-{group_safe}-",
+                "namespace": self.konflux_namespace,
+                "labels": {"appstudio.openshift.io/application": application_name},
+                "annotations": release_annotations,
+            },
+            "spec": {
+                "releasePlan": release_plan_name,
+                "snapshot": snapshot_name,
+            },
+        }
+        created_release = await self._konflux_client._create(release_obj)
+        release_name = created_release.metadata.name
+        release_url = self._konflux_client.resource_url(created_release)
+        logger.info("Created Release %s for Snapshot %s (%s)", release_name, snapshot_name, release_url)
+
+        # Poll for Release completion (30 min timeout, 30s interval)
+        timeout_s, poll_s, elapsed = 30 * 60, 30, 0
+        while elapsed < timeout_s:
+            release_obj = await self._konflux_client._get(API_VERSION, KIND_RELEASE, release_name)
+            for condition in release_obj.get("status", {}).get("conditions", []):
+                if condition.get("type") != "Released":
+                    continue
+                cond_status = condition.get("status")
+                reason = condition.get("reason", "")
+                if cond_status == "True" and reason == "Succeeded":
+                    logger.info("Stage release %s succeeded", release_name)
+                    return FbcRelatedImagesStageReleaseResult(
+                        snapshot_name=snapshot_name,
+                        release_name=release_name,
+                        release_url=release_url,
+                    )
+                if cond_status == "False" and reason == "Failed":
+                    message = condition.get("message", "No details")
+                    raise RuntimeError(f"Stage release {release_name} failed: {message}. See {release_url}")
+            if elapsed % 60 == 0:
+                logger.info("Stage release %s still progressing (%d min elapsed)", release_name, elapsed // 60)
+            await asyncio.sleep(poll_s)
+            elapsed += poll_s
+
+        raise RuntimeError(f"Stage release {release_name} timed out after 30 minutes. See {release_url}")
 
     async def build(
         self, metadata: ImageMetadata, operator_nvr: Optional[str] = None, git_auth_secret: Optional[str] = None

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -19,6 +19,7 @@ from artcommonlib.konflux.konflux_build_record import (
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.model import Missing
 from artcommonlib.util import (
+    resolve_konflux_fbc_stage_release_plan,
     resolve_konflux_kubeconfig_by_product,
     resolve_konflux_namespace_by_product,
 )
@@ -26,6 +27,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 
 from doozerlib import constants, opm
 from doozerlib.backend.konflux_fbc import (
+    FbcRebaseResult,
     KonfluxFbcBuilder,
     KonfluxFbcFragmentMerger,
     KonfluxFbcImporter,
@@ -495,6 +497,7 @@ class FbcRebaseAndBuildCli:
         major_minor: Optional[str] = None,
         insert_missing_entry: bool = False,
         skip_tasks: tuple[str, ...] = (),
+        stage_release_plan: Optional[str] = None,
     ):
         self.runtime = runtime
         self.version = version
@@ -516,6 +519,8 @@ class FbcRebaseAndBuildCli:
         self.prod_registry_auth = prod_registry_auth
         self.major_minor = major_minor
         self.insert_missing_entry = insert_missing_entry
+        self.stage_release_plan = stage_release_plan
+        self._ocp_version: Optional[Tuple[int, int]] = None  # set in run() after group config is loaded
         self._logger = LOGGER.getChild("FbcRebaseAndBuildCli")
         self._db_for_bundles = KonfluxDb()
         self._db_for_bundles.bind(KonfluxBundleBuildRecord)
@@ -672,7 +677,27 @@ class FbcRebaseAndBuildCli:
             await importer.import_from_index_image(operator_meta, index_image=None, strict=False)
 
         self._logger.info(f"Rebasing fbc for {operator_meta.name}...")
-        nvr = await rebaser.rebase(operator_meta, bundle_build, self.version, self.release)
+        rebase_result: FbcRebaseResult = await rebaser.rebase(operator_meta, bundle_build, self.version, self.release)
+        nvr = rebase_result.nvr
+
+        if self._should_stage_release():
+            release_plan = self.stage_release_plan
+            if not release_plan:
+                major, minor = self._ocp_version
+                release_plan = resolve_konflux_fbc_stage_release_plan(self.runtime.product, major, minor)
+            self._logger.info(
+                "Stage-releasing %d related image(s) for %s via ReleasePlan '%s'...",
+                len(rebase_result.ref_builds),
+                operator_meta.name,
+                release_plan,
+            )
+            stage_result = await builder.stage_release_related_images(
+                ref_builds=rebase_result.ref_builds,
+                release_plan_name=release_plan,
+                operator_name=operator_meta.distgit_key,
+            )
+            self._logger.info("Stage release succeeded for %s: %s", operator_meta.name, stage_result.release_url)
+
         self._logger.info(f"Building fbc for {operator_meta.name}...")
         _, pipelinerun_dict = await builder.build(
             operator_meta, operator_nvr=bundle_build.operator_nvr, git_auth_secret=git_auth_secret
@@ -684,6 +709,10 @@ class FbcRebaseAndBuildCli:
         if not pullspec:
             LOGGER.warning("Could not extract pullspec from pipelinerun results for %s", nvr)
         return nvr, pullspec
+
+    def _should_stage_release(self) -> bool:
+        """Stage release runs only for stream assembly."""
+        return self.runtime.assembly == "stream"
 
     async def run(self):
         """Rebase and build fbc fragments for given operator NVRs or all latest operator NVRs for the group and assembly"""
@@ -727,6 +756,7 @@ class FbcRebaseAndBuildCli:
                 )
         else:
             ocp_version = (runtime.group_config.vars.MAJOR, runtime.group_config.vars.MINOR)
+        self._ocp_version = (int(ocp_version[0]), int(ocp_version[1]))
 
         importer = KonfluxFbcImporter(
             base_dir=Path(runtime.working_dir, constants.WORKING_SUBDIR_KONFLUX_FBC_SOURCES),
@@ -930,6 +960,12 @@ class FbcRebaseAndBuildCli:
     default=False,
     help="Insert the new bundle entry in version order instead of appending. Use this to fix missing entries that were removed from the catalog.",
 )
+@click.option(
+    "--stage-release-plan",
+    metavar="NAME",
+    default=None,
+    help="Override the auto-resolved Konflux ReleasePlan name for stage-releasing related images before FBC build.",
+)
 @click.argument('operator_nvrs', nargs=-1, required=False)
 @pass_runtime
 @click_coroutine
@@ -953,6 +989,7 @@ async def fbc_rebase_and_build(
     prod_registry_auth: Optional[str],
     major_minor: Optional[str],
     insert_missing_entry: bool,
+    stage_release_plan: Optional[str],
     operator_nvrs: Tuple[str, ...],
 ):
     """
@@ -994,5 +1031,6 @@ async def fbc_rebase_and_build(
         prod_registry_auth=prod_registry_auth,
         major_minor=major_minor,
         insert_missing_entry=insert_missing_entry,
+        stage_release_plan=stage_release_plan,
     )
     await cli.run()

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -12,6 +12,7 @@ from doozerlib.backend.konflux_fbc import (
     BASE_IMAGE_RHEL8_PULLSPEC_FORMAT,
     BASE_IMAGE_RHEL9_PULLSPEC_FORMAT,
     AssemblyBundleCsvInfo,
+    FbcRebaseResult,
     KonfluxFbcBuilder,
     KonfluxFbcFragmentMerger,
     KonfluxFbcImporter,
@@ -360,10 +361,12 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         mock_opm.validate = AsyncMock()
         # Non-OpenShift group: release gets OCP version suffix
         expected_release = "1.ocp4.9"
-        mock_rebase_dir.return_value = f"test-distgit-key-fbc-1.0.0-{expected_release}"
+        expected_nvr = f"test-distgit-key-fbc-1.0.0-{expected_release}"
+        mock_rebase_dir.return_value = FbcRebaseResult(nvr=expected_nvr, ref_builds=[])
 
         actual = await self.rebaser.rebase(metadata, bundle_build, version, release)
-        self.assertEqual(actual, f"test-distgit-key-fbc-1.0.0-{expected_release}")
+        self.assertEqual(actual.nvr, expected_nvr)
+        self.assertEqual(actual.ref_builds, [])
 
         mock_build_repo.assert_called_once_with(
             url=self.fbc_repo,
@@ -409,11 +412,12 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         mock_opm.validate = AsyncMock()
         # Non-OpenShift group: release gets OCP version suffix
         expected_release = "1.ocp4.9"
-        mock_rebase_dir.return_value = f"test-distgit-key-fbc-1.0.0-{expected_release}"
+        expected_nvr = f"test-distgit-key-fbc-1.0.0-{expected_release}"
+        mock_rebase_dir.return_value = FbcRebaseResult(nvr=expected_nvr, ref_builds=[])
         self.rebaser.push = True
 
         actual = await self.rebaser.rebase(metadata, bundle_build, version, release)
-        self.assertEqual(actual, f"test-distgit-key-fbc-1.0.0-{expected_release}")
+        self.assertEqual(actual.nvr, expected_nvr)
 
         mock_build_repo.assert_called_once_with(
             url=self.fbc_repo,
@@ -564,7 +568,8 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         }
 
         actual = await self.rebaser._rebase_dir(metadata, build_repo, bundle_build, version, release, logger)
-        self.assertEqual(actual, "test-distgit-key-fbc-1.0.0-1")
+        self.assertIsInstance(actual, FbcRebaseResult)
+        self.assertEqual(actual.nvr, "test-distgit-key-fbc-1.0.0-1")
 
         mock_fetch_olm_bundle_image_info.assert_called_once_with(bundle_build)
         mock_fetch_olm_bundle_blob.assert_called_once_with(bundle_build, migrate_level="none")
@@ -3653,3 +3658,142 @@ class TestGenerateFbcBranchName(unittest.TestCase):
                 group="oadp-1.5", assembly="stream", distgit_key="oadp-operator", ocp_version=None
             )
         self.assertIn("ocp_version is required for non-OpenShift group 'oadp-1.5'", str(cm.exception))
+
+
+class TestKonfluxFbcBuilderStageRelease(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.group = "openshift-4.18"
+        self.assembly = "stream"
+        self.konflux_namespace = "ocp-art-tenant"
+
+        with patch("doozerlib.backend.konflux_fbc.KonfluxClient", spec=KonfluxClient) as MockKonfluxClient:
+            self.kube_client = MockKonfluxClient.from_kubeconfig.return_value = AsyncMock(spec=KonfluxClient)
+            self.builder = KonfluxFbcBuilder(
+                base_dir=Path("/tmp/fbc-stage-release-test"),
+                group=self.group,
+                assembly=self.assembly,
+                product="ocp",
+                db=MagicMock(),
+                fbc_repo="https://example.com/fbc.git",
+                konflux_namespace=self.konflux_namespace,
+                dry_run=False,
+            )
+
+    def _make_ref_build(self, name: str, pullspec: str):
+        build = MagicMock()
+        build.name = name
+        build.image_pullspec = pullspec
+        return build
+
+    async def test_stage_release_creates_snapshot_and_release(self):
+        ref_builds = [
+            self._make_ref_build("cluster-nfd-operator", "quay.io/openshift/cluster-nfd-operator@sha256:aaa"),
+            self._make_ref_build("nfd-operand", "quay.io/openshift/nfd@sha256:bbb"),
+        ]
+        release_plan_name = "ocp-art-advisory-stage-4-18"
+
+        snapshot_resource = MagicMock()
+        snapshot_resource.metadata.name = "fbc-ri-stage-openshift-4-18-cluster-nfd-operator-20260819120000"
+        release_resource = MagicMock()
+        release_resource.metadata.name = "fbc-ri-stage-openshift-4-18-abc123"
+        self.kube_client._create = AsyncMock(side_effect=[snapshot_resource, release_resource])
+        self.kube_client._get = AsyncMock(
+            side_effect=[
+                # Snapshot availability poll
+                snapshot_resource,
+                # ReleasePlan existence check
+                MagicMock(),
+                # Release poll — succeeded
+                {"status": {"conditions": [{"type": "Released", "status": "True", "reason": "Succeeded"}]}},
+            ]
+        )
+        self.kube_client.resource_url = MagicMock(return_value="https://konflux.example.com/release/abc")
+
+        from doozerlib.backend.konflux_fbc import FbcRelatedImagesStageReleaseResult
+
+        result = await self.builder.stage_release_related_images(ref_builds, release_plan_name, "cluster-nfd-operator")
+
+        self.assertIsInstance(result, FbcRelatedImagesStageReleaseResult)
+        self.assertEqual(result.release_url, "https://konflux.example.com/release/abc")
+
+        # Verify Snapshot structure
+        snapshot_call_args = self.kube_client._create.call_args_list[0][0][0]
+        self.assertEqual(snapshot_call_args["kind"], "Snapshot")
+        self.assertEqual(snapshot_call_args["spec"]["application"], "openshift-4-18")
+        self.assertEqual(len(snapshot_call_args["spec"]["components"]), 2)
+        self.assertEqual(snapshot_call_args["spec"]["components"][0]["containerImage"], ref_builds[0].image_pullspec)
+
+        # Verify Release structure
+        release_call_args = self.kube_client._create.call_args_list[1][0][0]
+        self.assertEqual(release_call_args["kind"], "Release")
+        self.assertEqual(release_call_args["spec"]["releasePlan"], release_plan_name)
+
+    async def test_stage_release_failure_raises(self):
+        ref_builds = [self._make_ref_build("my-operator", "quay.io/openshift/my-operator@sha256:abc")]
+        release_plan_name = "ocp-art-advisory-stage-4-18"
+
+        snapshot_resource = MagicMock()
+        snapshot_resource.metadata.name = "test-snapshot"
+        release_resource = MagicMock()
+        release_resource.metadata.name = "test-release"
+        self.kube_client._create = AsyncMock(side_effect=[snapshot_resource, release_resource])
+        self.kube_client._get = AsyncMock(
+            side_effect=[
+                snapshot_resource,
+                MagicMock(),
+                {
+                    "status": {
+                        "conditions": [
+                            {"type": "Released", "status": "False", "reason": "Failed", "message": "pipeline error"}
+                        ]
+                    }
+                },
+            ]
+        )
+        self.kube_client.resource_url = MagicMock(return_value="https://konflux.example.com/release/fail")
+
+        with self.assertRaises(RuntimeError) as cm:
+            await self.builder.stage_release_related_images(ref_builds, release_plan_name, "my-operator")
+        self.assertIn("failed", str(cm.exception).lower())
+        self.assertIn("https://konflux.example.com/release/fail", str(cm.exception))
+
+    async def test_stage_release_dry_run(self):
+        self.builder.dry_run = True
+        ref_builds = [self._make_ref_build("my-operator", "quay.io/openshift/my-operator@sha256:abc")]
+
+        from doozerlib.backend.konflux_fbc import FbcRelatedImagesStageReleaseResult
+
+        result = await self.builder.stage_release_related_images(
+            ref_builds, "ocp-art-advisory-stage-4-18", "my-operator"
+        )
+
+        self.assertIsInstance(result, FbcRelatedImagesStageReleaseResult)
+        self.assertIn("dry-run", result.release_name)
+        # No K8s calls should have been made
+        self.kube_client._create.assert_not_called()
+
+    async def test_stage_release_empty_ref_builds_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            await self.builder.stage_release_related_images([], "ocp-art-advisory-stage-4-18", "my-operator")
+        self.assertIn("No related image builds", str(cm.exception))
+
+    async def test_stage_release_release_plan_not_found_raises(self):
+        from kubernetes.dynamic import exceptions as k8s_exceptions
+
+        ref_builds = [self._make_ref_build("my-operator", "quay.io/openshift/my-operator@sha256:abc")]
+
+        snapshot_resource = MagicMock()
+        snapshot_resource.metadata.name = "test-snapshot"
+        self.kube_client._create = AsyncMock(return_value=snapshot_resource)
+        self.kube_client._get = AsyncMock(
+            side_effect=[
+                snapshot_resource,  # snapshot availability
+                k8s_exceptions.NotFoundError(MagicMock()),  # ReleasePlan not found
+            ]
+        )
+        self.kube_client.resource_url = MagicMock(return_value="https://konflux.example.com/snapshot/x")
+
+        with self.assertRaises(RuntimeError) as cm:
+            await self.builder.stage_release_related_images(ref_builds, "nonexistent-plan", "my-operator")
+        self.assertIn("nonexistent-plan", str(cm.exception))
+        self.assertIn("not found", str(cm.exception).lower())

--- a/doozer/tests/cli/test_fbc.py
+++ b/doozer/tests/cli/test_fbc.py
@@ -7,6 +7,7 @@ from artcommonlib.konflux.konflux_build_record import (
     KonfluxFbcBuildRecord,
 )
 from artcommonlib.model import Model
+from doozerlib.backend.konflux_fbc import FbcRebaseResult
 from doozerlib.cli.fbc import FbcImportCli, FbcRebaseAndBuildCli
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.runtime import Runtime
@@ -147,7 +148,7 @@ class TestFbcRebaseAndBuildCli(unittest.IsolatedAsyncioTestCase):
         self._setup_database_mocks(bundle_builds=[bundle_build], fbc_builds=[])
 
         mock_rebaser = mock.AsyncMock()
-        mock_rebaser.rebase.return_value = "test-fbc-1.0.0-1"
+        mock_rebaser.rebase.return_value = FbcRebaseResult(nvr="test-fbc-1.0.0-1", ref_builds=[])
         mock_rebaser_class.return_value = mock_rebaser
 
         mock_builder = mock.AsyncMock()
@@ -192,7 +193,7 @@ class TestFbcRebaseAndBuildCli(unittest.IsolatedAsyncioTestCase):
         self._setup_database_mocks(bundle_builds=[bundle_build], fbc_builds=[])
 
         mock_rebaser = mock.AsyncMock()
-        mock_rebaser.rebase.return_value = "test-fbc-1.0.0-1"
+        mock_rebaser.rebase.return_value = FbcRebaseResult(nvr="test-fbc-1.0.0-1", ref_builds=[])
         mock_rebaser_class.return_value = mock_rebaser
 
         mock_builder = mock.AsyncMock()
@@ -277,7 +278,7 @@ class TestFbcRebaseAndBuildCli(unittest.IsolatedAsyncioTestCase):
         self._setup_database_mocks(bundle_builds=[bundle_build], fbc_builds=[existing_fbc])
 
         mock_rebaser = mock.AsyncMock()
-        mock_rebaser.rebase.return_value = "test-fbc-1.0.0-2"
+        mock_rebaser.rebase.return_value = FbcRebaseResult(nvr="test-fbc-1.0.0-2", ref_builds=[])
         mock_rebaser_class.return_value = mock_rebaser
 
         mock_builder = mock.AsyncMock()
@@ -347,7 +348,7 @@ class TestFbcRebaseAndBuildCli(unittest.IsolatedAsyncioTestCase):
         self.mock_fbc_db.search_builds_by_fields = mock_fbc_search
 
         mock_rebaser = mock.AsyncMock()
-        mock_rebaser.rebase.return_value = "test-operator-1-fbc-1.0.0-1"
+        mock_rebaser.rebase.return_value = FbcRebaseResult(nvr="test-operator-1-fbc-1.0.0-1", ref_builds=[])
         mock_rebaser_class.return_value = mock_rebaser
 
         mock_builder = mock.AsyncMock()


### PR DESCRIPTION
## Summary

- Inserts a **Snapshot → Release → wait** step between FBC rebase and build so operator/operand images are pushed to advisory-stage before the FBC image is built. Failure blocks the FBC build.
- Adds `PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP` and `resolve_konflux_fbc_stage_release_plan()` for per-version ReleasePlan resolution per product (ocp, logging, oadp, rhmtc, mta).
- `KonfluxFbcRebaser.rebase()` now returns `FbcRebaseResult(nvr, ref_builds)` — `ref_builds` contains operator + operand builds, captured before the bundle is appended (bundle is IDMS-only and should not be stage-released).
- `KonfluxFbcBuilder.stage_release_related_images()`: creates one multi-component Snapshot per operator with all related images as components, creates a Release referencing the advisory-stage ReleasePlan, and polls for completion (30 min timeout, 30s interval — matching `BaseImageHandler`).
- Gate: stream assembly only. `--stage-release-plan` CLI option to override the auto-resolved ReleasePlan name.
- Snapshot uses the image-build application name (e.g. `openshift-4-18`) to match existing advisory-stage ReleasePlanAdmission bindings.

## Coordination

ReleasePlan template strings in `PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP` are provisional and must be updated once ART-17452 lands with the actual `konflux-release-data` ReleasePlan names.

## Test plan

- [ ] `uv run pytest doozer/tests/backend/test_konflux_fbc.py doozer/tests/cli/test_fbc.py` — 108 tests, all pass
- [ ] `make lint` — clean
- [ ] Dry-run smoke test: `doozer --group openshift-4.18 --assembly stream beta:fbc:rebase-and-build --dry-run ...` — verify stage release logs appear without creating K8s resources
- [ ] Integration (after ART-17452): run against stream with actual ReleasePlan, verify Snapshot + Release CRs are created and release completes before FBC build starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)